### PR TITLE
Fix file buffer handling in transcribe API

### DIFF
--- a/api/transcribe.js
+++ b/api/transcribe.js
@@ -1,8 +1,7 @@
 import pkg from 'formidable-serverless';
 const { IncomingForm } = pkg;
 import FormData from 'form-data';
-
-// ...el resto de tu código...
+import fs from 'fs';
 
 export const config = {
   api: {
@@ -36,11 +35,21 @@ export default async function handler(req, res) {
       return;
     }
 
-    // Usa buffer si existe, no filepath
+    // Lee el archivo desde buffer o desde el path temporal
     let fileBuffer = file.buffer;
     if (!fileBuffer) {
-      res.status(500).json({ error: 'No se pudo leer el archivo. (No hay buffer en el archivo subido)' });
-      return;
+      const path = file.filepath || file.path;
+      if (path) {
+        try {
+          fileBuffer = fs.readFileSync(path);
+        } catch (e) {
+          res.status(500).json({ error: 'No se pudo leer el archivo.' });
+          return;
+        }
+      } else {
+        res.status(500).json({ error: 'No se pudo leer el archivo. (buffer y path no disponibles)' });
+        return;
+      }
     }
 
     const formData = new FormData();


### PR DESCRIPTION
## Summary
- ensure `api/transcribe.js` can read uploaded audio either from an in-memory buffer or temporary file path
- add `fs` import and fallback to reading from `file.filepath`/`file.path`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68630b6c5e948331b7d2607c458cf875