### PR TITLE
Resolve form parsing error

### DIFF
--- a/api/transcribe.js
+++ b/api/transcribe.js
@@ -1,5 +1,4 @@
-import pkg from 'formidable-serverless';
-const { IncomingForm } = pkg;
+import { IncomingForm } from 'formidable';
 import FormData from 'form-data';
 import fs from 'fs';
 
@@ -22,7 +21,7 @@ export default async function handler(req, res) {
     return;
   }
 
-  const form = new IncomingForm();
+  const form = new IncomingForm({ maxFileSize: 25 * 1024 * 1024 });
   form.parse(req, async (err, fields, files) => {
     if (err) {
       res.status(500).json({ error: 'Error al procesar archivo', detail: err.message });


### PR DESCRIPTION
## Summary
- switch to `formidable` for improved multipart parsing
- bump file size limit when receiving uploads

## Testing
- `node -e "require('./api/transcribe.js')"`

------
https://chatgpt.com/codex/tasks/task_e_686310d0199c8331b21fae47825ce160